### PR TITLE
fix: Fix naming for AWS Budgets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ This module uses a specific `budgets` object for configurations - below paragrap
 ## EXAMPLES
 ```hcl
 module "aws_budgets" {
-  source  = "github.com/getindata/terraform-aws-budget"
+  source  = "github.com/getindata/terraform-aws-budget?ref=v1.0.0"
   context = module.this.context
 
   budgets = {

--- a/example/full-example/main.tf
+++ b/example/full-example/main.tf
@@ -1,5 +1,5 @@
 module "aws_budgets" {
-  source  = "github.com/getindata/terraform-aws-budget"
+  source  = "github.com/getindata/terraform-aws-budget?ref=v1.0.0"
   context = module.this.context
 
   budgets = {

--- a/modules/budget/main.tf
+++ b/modules/budget/main.tf
@@ -5,7 +5,7 @@
  */
 
 resource "aws_budgets_budget" "this" {
-  name              = replace(lookup(module.this.descriptors, "budget", module.this.id), "/-+/", "")
+  name              = replace(lookup(module.this.descriptors, "budget", module.this.id), "/--+/", "-")
   budget_type       = var.budget_type
   limit_amount      = var.limit_amount
   limit_unit        = var.limit_unit


### PR DESCRIPTION
Update regexp to allow single `-` in budget names